### PR TITLE
add an entry for homebrew on macos on apple silicon

### DIFF
--- a/library.lisp
+++ b/library.lisp
@@ -10,6 +10,7 @@
 (defparameter *tessdata-directory* 
   #+unix
   (namestring (or (probe-file "/usr/local/share/tessdata") ; Homebrew
+		  (probe-file "/opt/homebrew/share/tessdata")
                   (probe-file "/usr/local/tessdata")))
   #+windows
   (namestring (probe-file "C:\\Program Files\\Tesseract OCR\\tessdata"))


### PR DESCRIPTION
Library works great even 10 years later, just needs a new entry for /opt/homebrew on macOS